### PR TITLE
bump request to more recent version to remove security vunerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ot-discovery",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Discovery Client",
   "main": "discovery.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "author": "Steven Schlansker",
   "dependencies": {
     "node-uuid": "^1.4.2",
-    "request": "2.33.0"
+    "request": "^2.53.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
You are using an outdated version of the request library in this project, and one of its deps has two known security issues: 

https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
https://nodesecurity.io/advisories/qs_dos_memory_exhaustion

This pull request bumps the version, and fixes the dep. If you accept the request, please publish the new version. :)