### PR TITLE
bump logger to use lastest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "should": "^4.0.4"
   },
   "optionalDependencies": {
-    "ot-logger": "^0.0.14"
+    "ot-logger": "^0.0.15"
   },
   "bugs": {
     "url": "https://github.com/opentable/ot-discovery-nodejs/issues"


### PR DESCRIPTION
The logger also had the same dependencies and therefore the same security flaw; I've patched it and this is the corresponding bump to the dependency. 

Please merge and bump version.