### PR TITLE
logging info instead of error when unannounce succeeds

### DIFF
--- a/discovery.js
+++ b/discovery.js
@@ -296,7 +296,7 @@ DiscoveryClient.prototype.unannounce = function (announcement, callback) {
     if (error) {
       disco.logger.log('error', error);
     } else {
-      disco.logger.log("error", "Unannounce DELETE '" + url + "' returned " + response.statusCode + ": " + JSON.stringify(body));
+      disco.logger.log("info", "Unannounce DELETE '" + url + "' returned " + response.statusCode + ": " + JSON.stringify(body));
     }
     if (callback) {
       callback();


### PR DESCRIPTION
this was to correct a false error message in my log which had been generated when unannounce succeeded