### PR TITLE
Simplify notifier

### DIFF
--- a/src/AnnouncementIndex.coffee
+++ b/src/AnnouncementIndex.coffee
@@ -3,14 +3,14 @@ _ = require "lodash"
 
 class AnnouncementIndex
 
-  constructor:(@serverList, @discoveryNotifier) ->
-    # use the getter... not the direct private member!
+  constructor:(@serverList) ->
+    #use the getter... not the direct private member!
     @_announcements = {}
 
     @discoveryServers = []
     @index = -1
 
-  processUpdate:(update, shouldNotify) ->
+  processUpdate:(update) ->
     if update.fullUpdate
       @clearAnnouncements()
 
@@ -18,8 +18,6 @@ class AnnouncementIndex
     @removeAnnouncements(update.deletes)
     @addAnnouncements(update.updates)
     @computeDiscoveryServers()
-    if shouldNotify
-      @discoveryNotifier.notifyWatchers(update)
 
   removeAnnouncements:(ids=[]) ->
     @_announcements = _.omit(@_announcements, ids)
@@ -73,6 +71,5 @@ class AnnouncementIndex
 
   find:(predicate) ->
     _.sample @findAll(predicate)
-
 
 module.exports = AnnouncementIndex

--- a/src/DiscoveryClient.coffee
+++ b/src/DiscoveryClient.coffee
@@ -55,7 +55,7 @@ class DiscoveryClient
     @logger = @options?.logger or require "./ConsoleLogger"
     @discoveryNotifier = new DiscoveryNotifier @logger
     @serverList = new ServerList @logger
-    @announcementIndex = new AnnouncementIndex @serverList, @discoveryNotifier, @_homeRegionName
+    @announcementIndex = new AnnouncementIndex @serverList
     @discoveryConnector = new DiscoveryConnector @host, @_serviceName, @logger, @discoveryNotifier
     @discoveryLongPoller = new DiscoveryLongPoller @_serviceName, @serverList, @announcementIndex, @discoveryNotifier, @reconnect
 

--- a/src/DiscoveryClient.coffee
+++ b/src/DiscoveryClient.coffee
@@ -102,14 +102,20 @@ class DiscoveryClient
 
     announcedPromises = _.map @_discoveryAnnouncers, (announcer) ->
       announcer.announce announcement
-    Promise.all(announcedPromises).nodeify(callback)
+    Promise.all(announcedPromises).catch (e) =>
+      @discoveryNotifier.notifyError(e)
+      throw e
+    .nodeify(callback)
 
   unannounce: (announcements, callback) =>
     unannouncedPromises = _.map _.zip(@_discoveryAnnouncers, announcements),
       (announcementPair) ->
         announcementPair[0].unannounce announcementPair[1]
 
-    Promise.all(unannouncedPromises).nodeify(callback)
+    Promise.all(unannouncedPromises).catch (e) =>
+      @discoveryNotifier.notifyError(e)
+      throw e
+    .nodeify(callback)
 
   dispose: () ->
     @stopAnnouncementHeartbeat()

--- a/src/DiscoveryConnector.coffee
+++ b/src/DiscoveryConnector.coffee
@@ -5,40 +5,28 @@ request = Promise.promisify require("request")
 
 class DiscoveryConnector
 
-  constructor:(@host,@serviceName, @logger, @discoveryNotifier)->
-    @CONNECT_ATTEMPTS = 100
-    @INITIAL_BACKOFF = 500
+  constructor: (@host, @serviceName, @logger) ->
 
-  connectUrl:()->
+  connectUrl: ()->
     "http://#{@host}/watch" +  if @serviceName?  then "?clientServiceType=#{@serviceName}" else ""
 
-  connect:()->
-    Utils.promiseRetry(
-      @attemptConnect
-      @CONNECT_ATTEMPTS
-      @INITIAL_BACKOFF
-    )
-
-  attemptConnect:()=>
+  connect: () ->
     url = @connectUrl()
     @logger.log("debug", "Attempting connection to #{url}")
 
     request
       url: url
       json: true
-    .catch @discoveryNotifier.notifyAndReject
     .spread @handle
 
-  handle:(response, body)=>
+  handle: (response, body) =>
     if response.statusCode != 200
-      return @discoveryNotifier.notifyAndReject(
-        new Errors.DiscoveryConnectError(body))
+      throw new Errors.DiscoveryConnectError(body)
 
     update = body
 
     unless update?.fullUpdate
-      return @discoveryNotifier.notifyAndReject(
-        new Errors.DiscoveryFullUpdateError(update))
+      throw new Errors.DiscoveryFullUpdateError(update)
 
     @logger.log 'debug', 'Discovery update: ' + JSON.stringify(update)
 

--- a/src/DiscoveryLongPoller.coffee
+++ b/src/DiscoveryLongPoller.coffee
@@ -30,19 +30,18 @@ class DiscoveryLongPoller
     @currentRequest = request
       url:url
       json:true
-    .spread (response, body) =>
-      @handleResponse response
+    .spread @handleResponse
     .catch @handleError
     .finally () =>
       @schedulePoll()
       @currentRequest = null
 
-  handleError:(error)=>
+  handleError:(error) =>
     return unless @shouldBePolling
     @serverList.dropServer(@server)
     @discoveryNotifier.notifyError(error)
 
-  handleResponse: (response) ->
+  handleResponse: (response, body) =>
     return unless @shouldBePolling
     #no new updates
     unless response?.statusCode
@@ -54,8 +53,8 @@ class DiscoveryLongPoller
       error = new Error("Bad status code " + response.statusCode + " from watch: " + response)
       @handleError(error)
     else
-      @announcementIndex.processUpdate response.body
-      @discoveryNotifier.notifyWatchers response.body
+      @announcementIndex.processUpdate body
+      @discoveryNotifier.notifyWatchers body
 
 
 module.exports = DiscoveryLongPoller

--- a/src/DiscoveryLongPoller.coffee
+++ b/src/DiscoveryLongPoller.coffee
@@ -42,7 +42,7 @@ class DiscoveryLongPoller
     @serverList.dropServer(@server)
     @discoveryNotifier.notifyError(error)
 
-  handleResponse:(response)=>
+  handleResponse: (response) ->
     return unless @shouldBePolling
     #no new updates
     unless response?.statusCode
@@ -54,7 +54,8 @@ class DiscoveryLongPoller
       error = new Error("Bad status code " + response.statusCode + " from watch: " + response)
       @handleError(error)
     else
-      @announcementIndex.processUpdate(response.body, true)
+      @announcementIndex.processUpdate response.body
+      @discoveryNotifier.notifyWatchers response.body
 
 
 module.exports = DiscoveryLongPoller

--- a/src/DiscoveryLongPoller.coffee
+++ b/src/DiscoveryLongPoller.coffee
@@ -30,7 +30,7 @@ class DiscoveryLongPoller
           @currentRequest = request
             url:url
             json:true
-          , (err, response, body) =>
+          , (err, response, body) ->
             if err
               reject err
             else

--- a/src/DiscoveryNotifier.coffee
+++ b/src/DiscoveryNotifier.coffee
@@ -24,9 +24,4 @@ class DiscoveryNotifier
   onError:(fn)->
     @errorHandlers.push(fn)
 
-  notifyAndReject:(error)=>
-    @notifyError(error)
-    return Promise.reject(error)
-
-
 module.exports = DiscoveryNotifier

--- a/src/DiscoveryNotifier.coffee
+++ b/src/DiscoveryNotifier.coffee
@@ -1,10 +1,10 @@
 Promise = require "bluebird"
 Utils   = require "./Utils"
-
+_ = require "lodash"
 
 class DiscoveryNotifier
 
-  constructor:(@logger)->
+  constructor: (@logger) ->
     @errorHandlers = [
       @logger.log.bind(@logger, "error", "Discovery error: ")
     ]
@@ -12,11 +12,11 @@ class DiscoveryNotifier
       @logger.log.bind(@logger, "debug", "Discovery update: ")
     ]
 
-  notifyError:(error)->
-    Utils.invokeAll(@errorHandlers, error)
+  notifyError: (error) ->
+    _.invoke(@errorHandlers, _.call, null, error)
 
-  notifyWatchers:(body)->
-    Utils.invokeAll(@watchers, body)
+  notifyWatchers: (body) ->
+    _.invoke(@watchers, _.call, null, body)
 
   onUpdate:(fn)->
     @watchers.push(fn)

--- a/src/Utils.coffee
+++ b/src/Utils.coffee
@@ -8,7 +8,7 @@ class Utils
     MAX_BACKOFF = 10 * 1000
     fn().catch (e)=>
       if times < 1
-        Promise.reject(e)
+        throw e
       else
         Promise.delay(backoff).then =>
           newBackoff = Math.min(backoff * 2, MAX_BACKOFF)

--- a/src/Utils.coffee
+++ b/src/Utils.coffee
@@ -14,10 +14,6 @@ class Utils
           newBackoff = Math.min(backoff * 2, MAX_BACKOFF)
           @promiseRetry fn, times-1, newBackoff
 
-  invokeAll:(fns, args...)->
-    for fn in fns
-      fn.apply(null, args)
-
   generateUUID:()->
     uuid.v4()
 

--- a/test/unit/AnnouncementIndexSpec.coffee
+++ b/test/unit/AnnouncementIndexSpec.coffee
@@ -1,14 +1,12 @@
-
-AnnouncementIndex = require("#{srcDir}/AnnouncementIndex")
-sinon = require('sinon')
+AnnouncementIndex = require "#{srcDir}/AnnouncementIndex"
+sinon = require "sinon"
 
 describe "AnnouncementIndex", ->
   beforeEach ->
     @serverList =
       addServers: sinon.spy()
-    @discoveryNotifier =
-      notifyWatchers: sinon.spy()
-    @announcementIndex = new AnnouncementIndex @serverList, @discoveryNotifier
+
+    @announcementIndex = new AnnouncementIndex @serverList
     
     @sampleAnnouncements = [
       {
@@ -64,9 +62,8 @@ describe "AnnouncementIndex", ->
     expect(@serverList.addServers.calledWithMatch([@sampleAnnouncements[1].serviceUri]))
       .to.be.ok
 
-
   it "processUpdate - fullUpdate", ->
-    @announcementIndex.processUpdate({
+    @announcementIndex.processUpdate
       fullUpdate:true
       index:1
       deletes:[]
@@ -74,7 +71,7 @@ describe "AnnouncementIndex", ->
         {announcementId:"b1", serviceType:"gc-web", serviceUri:"gcweb.otenv.com"}
         {announcementId:"b2", serviceType:"discovery", serviceUri:"discovery.otenv.com"}
       ]
-    }, true)
+
     expect(@announcementIndex.getAnnouncements()).to.deep.equal {
       b1:
         announcementId: 'b1',
@@ -89,22 +86,9 @@ describe "AnnouncementIndex", ->
     expect(@announcementIndex.discoveryServers).to.deep.equal [
       "discovery.otenv.com"
     ]
-    expect(@discoveryNotifier.notifyWatchers.called).to.be.ok
-    expect(@discoveryNotifier.notifyWatchers.firstCall.args[0].index).to.equal 1
-
-  it "should not notify if processUpdate is called with shouldNotify =false", ->
-    @announcementIndex.processUpdate({
-      fullUpdate:true
-      index:1
-      deletes:[]
-      updates:[]
-    }, false)
-    expect(@announcementIndex.getAnnouncements()).to.deep.equal {}
-    expect(@announcementIndex.index).to.equal 1
-    expect(@discoveryNotifier.notifyWatchers.called).to.not.be.ok
 
   it "fullUpdate with removal of old items on new watch=x update, and fullUpdate:false", ->
-    @announcementIndex.processUpdate({
+    @announcementIndex.processUpdate
       fullUpdate:true
       index:1
       deletes:[]
@@ -112,13 +96,13 @@ describe "AnnouncementIndex", ->
         {announcementId:"b1", serviceType:"gc-web", serviceUri:"gcweb.otenv.com"}
         {announcementId:"b2", serviceType:"discovery", serviceUri:"discovery.otenv.com"}
       ]
-    }, false)
-    @announcementIndex.processUpdate({
+
+    @announcementIndex.processUpdate
       fullUpdate:false
       index:2
       deletes:["b1"]
       updates:[]
-    }, false)
+
     expect(@announcementIndex.getAnnouncements()).to.deep.equal {
       b2:
         announcementId: 'b2',
@@ -163,7 +147,7 @@ describe "AnnouncementIndex multi region", ->
     beforeEach ->
       @serverList =
         addServers: sinon.spy()
-      @announcementIndex = new AnnouncementIndex @serverList, null
+      @announcementIndex = new AnnouncementIndex @serverList
       
       @sampleAnnouncements = [
         {

--- a/test/unit/DiscoveryAnnouncerSpec.coffee
+++ b/test/unit/DiscoveryAnnouncerSpec.coffee
@@ -81,7 +81,7 @@ describe "DiscoveryAnnouncer", ->
           .reply(400, "Simulated error")
 
       @announcer.announce(@announcement)
-        .catch (e) =>
+        .catch (e) ->
           watch.done()
           failure.done()
           expect(e.message).to.equal 'During announce, bad status code 400:"Simulated error"'
@@ -123,8 +123,8 @@ describe "DiscoveryAnnouncer", ->
           .reply(500)
 
       @announcer.announce(@announcement)
-        .catch (e) =>
-          expect(e).to.be.ok;
+        .catch (e) ->
+          expect(e).to.be.ok
           done()
 
     it "watch rejects", (done) ->

--- a/test/unit/DiscoveryAnnouncerSpec.coffee
+++ b/test/unit/DiscoveryAnnouncerSpec.coffee
@@ -17,12 +17,18 @@ describe "DiscoveryAnnouncer", ->
     @announcer = new DiscoveryAnnouncer @logger, @discoveryHost
 
     @discoAnnouncements =
+      fullUpdate: true
       updates: [
         {
           announcementId:"disco"
           serviceType : "discovery"
           serviceUri  : @discoveryServer
-        }
+        },
+        {
+          announcementId:"other"
+          serviceType : "other"
+          serviceUri  : "foobar"
+        },
       ]
 
     @announcement = {
@@ -30,6 +36,19 @@ describe "DiscoveryAnnouncer", ->
       serviceType : "my-new-service",
       serviceUri  : "http://my-new-service:8080"
     }
+
+  describe "connect", ->
+    it "calls connector.connect and plucks disco only", (done) ->
+      watch =
+        nock("http://#{@discoveryHost}")
+          .get('/watch')
+          .reply(200, @discoAnnouncements)
+
+      @announcer.connect().then () =>
+        discoServers = [@discoveryServer]
+        expect(@announcer.serverList.servers).to.deep.equal(discoServers)
+        watch.done()
+        done()
 
   describe "announce", ->
     it "announce() success", (done) ->

--- a/test/unit/DiscoveryClientSpec.coffee
+++ b/test/unit/DiscoveryClientSpec.coffee
@@ -100,15 +100,19 @@ describe "DiscoveryClient", ->
         done()
       .catch(done)
 
-    it "announce fails if one announce fails", (done) ->
+    it "announce fails if one announce fails and error watchers", (done) ->
       @announcers[0].announce = sinon.spy (announce) ->
         Promise.resolve(announce)
       @announcers[1].announce = sinon.spy (announce) ->
         Promise.reject new Error('an error')
 
+      errorSpy = sinon.spy()
+      @discoveryClient.onError errorSpy
+
       @discoveryClient.announce({}).then (result) ->
         done new Error('should not get here')
       .catch (err) ->
+        expect(errorSpy.called).to.be.ok
         expect(err).to.be.ok
         done()
 
@@ -125,14 +129,18 @@ describe "DiscoveryClient", ->
         done()
       .catch(done)
 
-    it "unannounce fails if one unannounce fails", (done) ->
+    it "unannounce fails if one unannounce fails and error watchers", (done) ->
       @announcers[0].unannounce = sinon.spy()
       @announcers[1].unannounce = sinon.spy () ->
         Promise.reject new Error('something')
 
+      errorSpy = sinon.spy()
+      @discoveryClient.onError errorSpy
+
       @discoveryClient.unannounce([1,2]).then () ->
         done new Error('should not get here')
-      .catch (err) ->
+      .catch (err) =>
+        expect(errorSpy.called).to.be.ok
         expect(err).to.be.ok
         done()
 

--- a/test/unit/DiscoveryClientSpec.coffee
+++ b/test/unit/DiscoveryClientSpec.coffee
@@ -52,9 +52,9 @@ describe "DiscoveryClient", ->
         }]
 
       @discoveryClient.discoveryConnector.connect = sinon.spy () ->
-        return Promise.resolve(updates)
+        Promise.resolve updates
 
-      sinon.spy(@discoveryClient.announcementIndex, 'processUpdate')
+      sinon.spy @discoveryClient.announcementIndex, 'processUpdate'
       @discoveryClient.longPollForUpdates = sinon.spy()
       @discoveryClient.startAnnouncementHeartbeat = sinon.spy()
       @discoveryClient.connect (err, host, servers) =>
@@ -70,6 +70,14 @@ describe "DiscoveryClient", ->
         expect(host).to.equal(api2testHosts.discoverRegionHost)
         expect(servers).to.deep.equal(['a.disco'])
 
+        done()
+
+    it "connect notifies and errors on failure", (done) ->
+      @discoveryClient.discoveryConnector.connect = sinon.spy () ->
+        Promise.reject new Error('badness')
+
+      @discoveryClient.connect (err) ->
+        expect(err).to.be.ok
         done()
 
     it "heartbeat start calls heartbeat on each region", ->

--- a/test/unit/DiscoveryConnectorSpec.coffee
+++ b/test/unit/DiscoveryConnectorSpec.coffee
@@ -11,16 +11,10 @@ describe "DiscoveryConnector", ->
     nock.cleanAll()
     nock.disableNetConnect()
     @host = "ahost.com"
-    @discoveryNotifier =
-      notifyAndReject: sinon.spy (err) ->
-        Promise.reject err
     @logger =
       log: sinon.spy()
-      
-    @connector = new DiscoveryConnector @host, null, @logger, @discoveryNotifier
-    sinon.spy(Utils, "promiseRetry")
-    @getRetryCalls = ->
-      _.pluck(Utils.promiseRetry.getCalls(), "args")
+
+    @connector = new DiscoveryConnector @host, null, @logger
 
     @discoveryServer = "http://" + @host
 
@@ -47,54 +41,46 @@ describe "DiscoveryConnector", ->
       }
 
   afterEach ->
-    nock.cleanAll()
-    Utils.promiseRetry.restore()
+    nock.cleanAll();
 
   describe "connect", ->
-    it "failure after 3 attempts", (done)->
-      @connector.CONNECT_ATTEMPTS = 3
-      @connector.INITIAL_BACKOFF = 1
-
+    it "fails from catch", (done) ->
       @connector.connect()
-        .catch (e)=>
+        .catch (e) =>
           expect(e.message).to.equal(
             'Nock: Not allow net connect for "' + @host + ':80/watch"')
-          expect([
-            [@connector.attemptConnect, 3, 1]
-            [@connector.attemptConnect, 2, 2]
-            [@connector.attemptConnect, 1, 4]
-            [@connector.attemptConnect, 0, 8]
-          ]).to.deep.equal @getRetryCalls()
           done()
 
-    it "success after 4 attempts", (done)->
-      @connector.CONNECT_ATTEMPTS = 10
-      @connector.INITIAL_BACKOFF = 1
+    it "fails from non-good status code", (done) ->
       failedRequests =
         nock(@discoveryServer)
           .get("/watch")
-          .times(2)
           .reply(500, "Simulated server error")
+      @connector.connect()
+        .catch (e) =>
+          expect(e).to.be.ok
+          done()
+
+    it "fails from a non-full update", (done) ->
       nonFullUpdateRequests =
         nock(@discoveryServer)
           .get("/watch")
-          .times(2)
           .reply(500, {fullUpdate:false})
+      @connector.connect()
+        .catch (e) =>
+          expect(e).to.be.ok
+          done()
+
+
+    it "success", (done) ->
       successfulRequest =
         nock(@discoveryServer)
           .get("/watch")
           .reply(200, @successfulUpdate)
-        
+
       @connector.connect().then (result) =>
-        failedRequests.done()
-        nonFullUpdateRequests.done()
         successfulRequest.done()
         expect(result).to.deep.equal @successfulUpdate
-
-        expect @discoveryNotifier.notifyAndReject.calledWithMatch 'Unabled to initiate discovery: "Simulated server error"',
-          'Unabled to initiate discovery: "Simulated server error"',
-          'Unabled to initiate discovery: {"fullUpdate":false}',
-          'Unabled to initiate discovery: {"fullUpdate":false}'
         done()
 
     describe 'api v2', () ->

--- a/test/unit/DiscoveryLongPollerSpec.coffee
+++ b/test/unit/DiscoveryLongPollerSpec.coffee
@@ -19,8 +19,8 @@ describe "DiscoveryLongPoller", ->
       processUpdate: sinon.spy()
 
     @discoveryNotifier =
-      notifyError: sinon.spy (error) ->
-        Promise.reject(error)
+      notifyError: sinon.spy()
+      notifyWatchers: sinon.spy()
 
     @reconnect = sinon.spy()
 
@@ -66,7 +66,7 @@ describe "DiscoveryLongPoller", ->
     beforeEach ->
       @discoveryLongPoller.shouldBePolling = true
 
-    it "calls process if 200", (done) ->
+    it "calls process and watchers if 200", (done) ->
       @announcementIndex.index = 1
       nock(@discoveryServer)
         .get("/watch?since=2&clientServiceType=#{testServiceName}")
@@ -74,6 +74,7 @@ describe "DiscoveryLongPoller", ->
 
       @discoveryLongPoller.schedulePoll = () ->
         expect(@announcementIndex.processUpdate.called).to.be.ok
+        expect(@discoveryNotifier.notifyWatchers.called).to.be.ok
         done()
 
       @discoveryLongPoller.poll()

--- a/test/unit/DiscoveryNotifierSpec.coffee
+++ b/test/unit/DiscoveryNotifierSpec.coffee
@@ -22,14 +22,3 @@ describe "DiscoveryNotifier", ->
     expect(@logger.log.calledWithMatch("debug", "Discovery update: ", "someUpdate"))
       .to.be.ok
     expect(@recievedUpdate).to.equal "someUpdate"
-
-  it "notifyAndReject()", (done)->
-    error = new Error("oops")
-    @notifier.onError (@notifiedError)=>
-
-    @notifier.notifyAndReject(error).catch (recievedError)=>
-      expect(recievedError).to.equal error
-      expect(@notifiedError).to.equal error
-      done()
-
-

--- a/test/unit/ServerListSpec.coffee
+++ b/test/unit/ServerListSpec.coffee
@@ -1,5 +1,6 @@
 ServerList = require("#{srcDir}/ServerList")
 sinon = require "sinon"
+Promises = require "bluebird"
 
 describe "ServerList", ->
   beforeEach ->
@@ -24,11 +25,43 @@ describe "ServerList", ->
     @serverList.servers = ["s1"]
     expect(@serverList.isEmpty()).to.equal false
 
-  it "getRandom()", ->
-    @serverList.servers = ["s1", "s2", "s3"]
+  describe "getRandom", ->
+    before () ->
+      @servers = ["s1", "s2"]
 
-    expect(@serverList.getRandom() in @serverList.servers)
-      .to.equal true
+    it "returns an promise that resolves when there are servers", (done) ->
+      @connect = sinon.spy () ->
+        done new Error("should not be called")
+
+      @serverList.addServers @servers
+
+      @serverList.getRandom()
+        .then (server) =>
+          expect(server in @servers).to.equal true
+          done()
+        .catch(done)
+
+    it "calls connect to get more servers when there is not", (done) ->
+      @serverList.connect = sinon.spy () =>
+        @serverList.addServers @servers
+        Promises.resolve()
+
+      @serverList.getRandom()
+        .then (server) =>
+          expect(server in @servers).to.equal true
+          expect(@serverList.connect.called).to.be.ok
+          done()
+        .catch(done)
+
+    it "will reject if connect fail", (done) ->
+      @serverList.connect = sinon.spy () ->
+        Promises.reject new Error("badness")
+
+      @serverList.getRandom()
+        .then (server) ->
+          done new Error("Should not be called")
+        .catch (err) ->
+          done()
 
   it "dropServer()", ->
     @serverList.servers = ["s1", "s2"]

--- a/test/unit/UtilsSpec.coffee
+++ b/test/unit/UtilsSpec.coffee
@@ -33,21 +33,6 @@ describe "Utils", ->
       expect(result).to.equal("success:10")
       done()
 
-
-
-  it "invokeAll()", ->
-    str = ""
-
-    fn = (args...)->
-      str += args.join("")
-
-    fns = [fn, fn]
-
-    Utils.invokeAll(fns, "a", "b")
-
-    expect(str).to.equal "abab"
-
-
   it "delegateMethods", ->
     delegate = {
       foo:(@fooArgs...)=>


### PR DESCRIPTION
Largely, move the code for "exceptional situations" out of the subclasses into the `DiscoveryClient` itself, lowering dependency chains and making things less tight.

Interesting things:

* `ServerList` now decides when a reconnect is needed and `getRandomServer` is promise based now.
* DiscoveryAnnouncer now uses `ServerList` and `DiscoveryConnector` instead of rolling its own code.
* We don't retry on connect nor announcements anymore. Connect tries once and fails; this is per the original API. Announce tries once because it will retry in 10 seconds anyway, and the back off is such that after 2 retries it'll hit 10 seconds (1,2,4,8)

There are a few other things I want to do:
* merge the connector versus watch code
* improve test branch coverage to 90%

but this PR is too big already.