### PR TITLE
fixed filter paths... add gulplogwarn

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var minimist = require('minimist');
 var _ = require('lodash');
 var coffeelint = require('gulp-coffeelint');
 var jshint = require('gulp-jshint');
+var logwarn = require('gulp-logwarn');
 
 var defaultPaths = {
   scripts: ['src/**/*.coffee', 'src/**/*.js'],
@@ -24,6 +25,8 @@ var defaultPaths = {
   coverage: 'coverage/',
   zipCoverage: 'coverage/*'
 };
+
+var logStr = ['console' + '.log'];
 
 var defaultCoverageThresholds = {
   statements: 90,
@@ -39,12 +42,14 @@ function createFilteredPaths(normalPaths, toFilterPaths) {
 }
 
 function filterPaths(filetype, pathObject) {
-  return _.filter(
-    _.flatten(pathObject.scripts, pathObject.tests),
-    function(path) {
-      return path.indexOf(filetype) > 0;
-    }
-  );
+  var array = [];
+  var filterFunc = function(path) {
+    return path.indexOf(filetype) > 0;
+  };
+  array.concat(_.chain(pathObject.scripts)
+    .filter(filterFunc).value());
+  return array.concat(_.chain(pathObject.tests)
+    .filter(filterFunc).value());
 }
 
 function test(path, opts) {
@@ -109,6 +114,7 @@ gulp.task('test-all-coverage', function(cb) {
 gulp.task('coffeelint', function() {
   var src = filterPaths('.coffee', defaultPaths);
   gulp.src(src)
+    .pipe(logwarn(logStr))
     .pipe(coffeelint({
       'max_line_length': {
         'level': 'ignore'
@@ -122,6 +128,7 @@ gulp.task('jslint', function() {
   var src = filterPaths('.js', defaultPaths);
   src.push('gulpfile.js');
   return gulp.src(src)
+    .pipe(logwarn(logStr))
     .pipe(jshint())
     .pipe(jshint.reporter())
     .pipe(jshint.reporter('fail'));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-istanbul": "^0.10.0",
     "gulp-istanbul-enforcer": "^1.0.3",
     "gulp-jshint": "^1.11.2",
+    "gulp-logwarn": "0.0.8",
     "gulp-mocha": "^2.1.3",
     "isparta": "^3.0.3",
     "minimist": "^1.1.2",

--- a/test/unit/DiscoveryClientSpec.coffee
+++ b/test/unit/DiscoveryClientSpec.coffee
@@ -9,14 +9,14 @@ describe "DiscoveryClient", ->
       return new (Function.prototype.bind.apply(DiscoveryClient,[null].concat(params)))
 
     @expectThrow = (params, throwMessage) ->
-      expect(() => 
+      expect(() =>
         @createDisco(params)
       ).to.throw(throwMessage)
 
     @expectNotToThrow = (params) ->
       disco = null
-      expect(() => 
-        disco = @createDisco params 
+      expect(() =>
+        disco = @createDisco params
       ).to.not.throw()
       disco
   


### PR DESCRIPTION
@lastquestion  ... I told you .flatten doesn't always work so hot...

It wasn't combining in the .tests paths so we weren't linting tests for a few commits (nothing big and stuff I did tbh...)