### PR TITLE
clone announcement hash per region, so we create new ids per region

### DIFF
--- a/src/DiscoveryClient.coffee
+++ b/src/DiscoveryClient.coffee
@@ -133,7 +133,9 @@ class DiscoveryClient
       announcement.environment = @_homeRegionName
 
     announcedPromises = _.map @_discoveryAnnouncers, (announcer) ->
-      announcer.announce announcement
+      # we need to clone each announcement so each announcement in each region
+      # gets a new announcementId
+      announcer.announce _.extend({}, announcement)
 
     Promise.all(announcedPromises).catch (e) =>
       @discoveryNotifier.notifyError(e)

--- a/test/unit/DiscoveryClientSpec.coffee
+++ b/test/unit/DiscoveryClientSpec.coffee
@@ -205,7 +205,7 @@ describe "DiscoveryClient", ->
         replaceMethod ann, 'announce', sinon.spy (announce) ->
           Promise.resolve announce
       announcement = {}
-      @discoveryClient.announce(announcement).then (result) =>
+      @discoveryClient.announce(announcement).then (result) ->
         expect(result[0]).to.have.property('environment').to.equal 'homeregion'
         done()
       .catch done
@@ -218,7 +218,7 @@ describe "DiscoveryClient", ->
       announcement = {}
       @discoveryClient._homeRegionName = null
 
-      @discoveryClient.announce(announcement).then (result) =>
+      @discoveryClient.announce(announcement).then (result) ->
         expect(result[0]).to.not.have.property 'environment'
         done()
       .catch done
@@ -227,9 +227,11 @@ describe "DiscoveryClient", ->
       _.each @announcers, (ann) ->
         replaceMethod ann, 'announce', sinon.spy (announce) ->
           Promise.resolve(announce)
+
       announcement =
         serviceName: 'service'
         serviceUri: 'foobar.com'
+
       @discoveryClient.announce(announcement).then (lease) =>
         expect(announcement).to.deep.equal {
           serviceName: 'service'
@@ -241,6 +243,8 @@ describe "DiscoveryClient", ->
         _.each @announcers, (ann) ->
           expect(ann.announce.firstCall.args[0].serviceName).to.equal 'service'
           expect(ann.announce.firstCall.args[0].serviceUri).to.equal 'foobar.com'
+          expect(ann.announce.firstCall.args[0]).to.not.have.property 'announcementId'
+
         done()
       .catch(done)
 


### PR DESCRIPTION
This way each announcement in each region gets its own `announcementId`.

I put the test in the existing test. Just making sure that each `DiscoveryAnnouncer` gets it's own non-set `announcementId`.