### PR TITLE
unannounce does nothing if requested to unannounce something already …

### DIFF
--- a/src/DiscoveryAnnouncer.coffee
+++ b/src/DiscoveryAnnouncer.coffee
@@ -62,6 +62,9 @@ module.exports = class DiscoveryAnnouncer
     announcement
 
   unannounce: (announcement) ->
+    #if we already unannounced successfully, do nothing.
+    return Promise.resolve() unless @_announcedRecords[announcement.announcementId]
+
     @serverList.getRandom()
       .then (server) =>
         url = "#{server}/announcement/#{announcement.announcementId}"
@@ -74,6 +77,7 @@ module.exports = class DiscoveryAnnouncer
           delete @_announcedRecords[announcement.announcementId]
           @logger.log "info", "Unannounce DELETE '#{url}' " +
             "returned #{response.statusCode}:#{JSON.stringify(body)}"
+          return
         .catch (e) =>
           @serverList.dropServer server
           throw e

--- a/test/unit/DiscoveryAnnouncerSpec.coffee
+++ b/test/unit/DiscoveryAnnouncerSpec.coffee
@@ -255,7 +255,7 @@ describe "DiscoveryAnnouncer", ->
       # in this test, we won't test the server list / watch which is tested
       # in the suite for 'announce'
       @announcer.serverList.addServers [@discoveryServer]
-      @announcer.handleResponse {statusCode: 201}, @announcement
+      @announcer._announcedRecords[@announcement.announcementId] = @announcement
 
     it "unannounce - error - rejection", (done) ->
       unannounce =
@@ -283,9 +283,39 @@ describe "DiscoveryAnnouncer", ->
       unannounceRequest = nock(@discoveryServer)
         .delete("/announcement/a1")
         .reply(200)
-      @announcer.unannounce(@announcement).then (result) ->
+      @announcer.unannounce(@announcement).then () ->
         done()
       .catch(done)
+
+    it "unannounce - does nothing", (done) ->
+      @announcer._announcedRecords = {}
+      @announcer.unannounce(@announcement).then () ->
+        done()
+      .catch(done)
+
+    it "unannounce - fail then success then nothing", (done) ->
+      fail = nock @discoveryServer
+        .delete "/announcement/a1"
+        .reply 500
+
+      success = nock @discoveryServer
+        .delete "/announcement/a1"
+        .reply 200
+
+      @announcer.unannounce(@announcement).then () ->
+        done new Error("should not get here")
+      .catch (e) =>
+        #it was dropped; readd it so we don't have to mock disco-request
+        @announcer.serverList.addServers [@discoveryServer]
+
+        @announcer.unannounce(@announcement)
+          .then () =>
+            @announcer.unannounce(@announcement)
+          .then () ->
+            fail.done()
+            success.done()
+            done()
+          .catch done
 
   describe "heartbeats", () ->
     before () ->


### PR DESCRIPTION
…unannounced

Basically this allows clients to `unannounce` across regions again and again until it succeeds.